### PR TITLE
Reverse Email/Phone THs on Contacts page

### DIFF
--- a/app/containers/Contacts.jsx
+++ b/app/containers/Contacts.jsx
@@ -97,8 +97,8 @@ class Contacts extends Component {
                 <THead>
                   <TR>
                     <TH>Contact</TH>
-                    <TH>Phone</TH>
                     <TH>Email</TH>
+                    <TH>Phone</TH>
                     <TH actions>Actions</TH>
                   </TR>
                 </THead>


### PR DESCRIPTION
As of now, the labels on the head of the table on the Contacts page have email + phone reversed from how they're displayed in the table rows:

https://github.com/hql287/Manta/blob/dev/app/components/contacts/Contact.jsx#L34-L43

This is a quick fix!