### PR TITLE
Fix Blank Screen on Startup Issue

### DIFF
--- a/app.js
+++ b/app.js
@@ -196,11 +196,11 @@ function setInitialValues() {
       },
     },
   };
+
   // Set initial values conditionally
   for (const key in defaultOptions) {
     if (!appConfig.has(`${key}`)) {
       appConfig.set(`${key}`, defaultOptions[key]);
-      break;
     }
     for (const childKey in defaultOptions[key]) {
       if (!appConfig.has(`${key}.${childKey}`)) {


### PR DESCRIPTION
Fix https://github.com/hql287/Manta/issues/154

In `setInitialValues()`, there's an unexpected `break` statement in the `for .. in` loop. This caused the loop to quit unfinished and led to many values in defaultOptions didn’t get saved to appConfig.

In the frontend, the `FormReducer` was looking for these missing values but coudldn't find them, resulting in the blank screen. 