### PR TITLE
Always display tour window in the center of primary display

### DIFF
--- a/app.js
+++ b/app.js
@@ -10,7 +10,8 @@ const isDev = require('electron-is-dev');
 const omit = require('lodash').omit;
 
 // Electron Libs
-const { app, BrowserWindow, ipcMain } = require('electron');
+const electron = require('electron');
+const { app, BrowserWindow, ipcMain } = electron;
 
 // Prevent Linux GPU Bug
 // https://github.com/electron/electron/issues/4322
@@ -26,11 +27,34 @@ let tourWindow = null;
 let mainWindow = null;
 let previewWindow = null;
 
+// Calculate X and Y position
+function calPOS(displayBounds, winBounds) {
+  // Explicitly name these values
+  const displayX = displayBounds.x;
+  const displayY = displayBounds.y;
+  const displayWidth = displayBounds.width;
+  const displayHeight = displayBounds.height;
+  const winX = displayX + ( displayWidth - winBounds.width) / 2;
+  const winY = displayY + ( displayHeight - winBounds.height ) / 2;
+  return {
+    x: winX,
+    y: winY,
+  }
+}
+
 function createTourWindow() {
+  const screen = electron.screen;
+  const primaryDisplayBounds = screen.getPrimaryDisplay().bounds;
+  const width = 700;
+  const height = 600;
+  const winPOS = calPOS(primaryDisplayBounds, { width, height });
+
   // Creating a New Window
   tourWindow = new BrowserWindow({
-    width: 700,
-    height: 600,
+    x: winPOS.x,
+    y: winPOS.y,
+    width,
+    height,
     show: false,
     frame: false,
     resizable: false,


### PR DESCRIPTION
Fix #91 

![case 1](https://user-images.githubusercontent.com/2544327/34983475-3f0830c8-fae0-11e7-83cd-d860770ff9a7.png)
![case 2](https://user-images.githubusercontent.com/2544327/34983476-3f4ab5f6-fae0-11e7-9ef1-abc6564066d1.png)

@AlphaStyle Can you test this PR on your machine to see if it works? 
The result for case 1 should be `{ x: 40, y: 40 }` and case 2 should be `{ x: 240, y: 40 }` 

Thanks!