### PR TITLE
Update currency: Zambian Kwacha

### DIFF
--- a/libs/currencies.json
+++ b/libs/currencies.json
@@ -1052,13 +1052,13 @@
     "code": "ZAR",
     "name_plural": "South African rand"
   },
-  "ZMK": {
-    "symbol": "ZK",
+  "ZMW": {
+    "symbol": "K",
     "name": "Zambian Kwacha",
-    "symbol_native": "ZK",
-    "decimal_digits": 0,
+    "symbol_native": "K",
+    "decimal_digits": 2,
     "rounding": 0,
-    "code": "ZMK",
+    "code": "ZMW",
     "name_plural": "Zambian kwachas"
   }
 }


### PR DESCRIPTION
ZMK is actually invalid as of 2013 when the Zambian Kwacha was rebased. The ISO 3 code is now ZMW.
Additionally we use "K" as the currency symbol & use 2 decimal digits.
References: [Wiki ISO_4217](https://en.wikipedia.org/wiki/ISO_4217) & [Wiki New Zambian Kwacha](https://en.wikipedia.org/wiki/Zambian_kwacha#New_Kwacha_(2012_series))