### PR TITLE
[WIP] Enable empty rows in form

### DIFF
--- a/app.js
+++ b/app.js
@@ -188,6 +188,8 @@ function setInitialValues() {
       previewPDF: true,
       checkUpdate: 'daily',
       lastCheck: Date.now(),
+      // Empty Row checker
+      enableEmptyRow: false,
     },
     invoice: {
       exportDir: os.homedir(),

--- a/app/components/settings/General.jsx
+++ b/app/components/settings/General.jsx
@@ -86,6 +86,22 @@ class General extends Component {
             </div>
           </div>
         </div>
+        <div className="row">
+          <div className="col-md-6">
+            <div className="pageItem">
+              <label className="itemLabel">Enable empty rows</label>
+              <label className="switch">
+                <input
+                  name="enableEmptyRow"
+                  type="checkbox"
+                  checked={this.state.enableEmptyRow}
+                  onChange={this.handleInputChange}
+                />
+                <span className="slider round" />
+              </label>
+            </div>
+          </div>
+        </div>
       </div>
     );
   }

--- a/app/helpers/form.js
+++ b/app/helpers/form.js
@@ -102,38 +102,42 @@ function validateRecipient(recipient) {
 
 function validateRows(rows) {
   let validated = true;
-  for (let i = 0; i < rows.length; i++) {
-    const row = rows[i];
-    // Does it contain description?
-    if (!row.description) {
+  // Added this check as per issue #97 "Allow product lines to be left empty or partially filled in"
+  if (enableEmptyRow === false) {
+    for (let i = 0; i < rows.length; i++) {
+      const row = rows[i];
+      // Does it contain description?
+      if (!row.description) {
       openDialog({
-        type: 'warning',
-        title: 'Required Field',
-        message: 'Description can not be blank',
-      });
-      validated = false;
-      break;
+          type: 'warning',
+          title: 'Required Field',
+          message: 'Description can not be blank',
+        });
+        validated = false;
+        break;
+      }
+      // Is the price presented and greater than 0?
+      if (!row.price || row.price === 0) {
+        openDialog({
+          type: 'warning',
+          title: 'Required Field',
+          message: 'Price must be greater than 0',
+        });
+        validated = false;
+        break;
+      }
+      // Is the quantity presented and greater than 0?
+      if (!row.quantity || row.quantity === 0) {
+        openDialog({
+          type: 'warning',
+          title: 'Required Field',
+          message: 'Quantity must be greater than 0',
+        });
+        validated = false;
+        break;
+      }
     }
-    // Is the price presented and greater than 0?
-    if (!row.price || row.price === 0) {
-      openDialog({
-        type: 'warning',
-        title: 'Required Field',
-        message: 'Price must be greater than 0',
-      });
-      validated = false;
-      break;
-    }
-    // Is the quantity presented and greater than 0?
-    if (!row.quantity || row.quantity === 0) {
-      openDialog({
-        type: 'warning',
-        title: 'Required Field',
-        message: 'Quantity must be greater than 0',
-      });
-      validated = false;
-      break;
-    }
+    return validated;
   }
   return validated;
 }


### PR DESCRIPTION
I'm trying to add the feature requested as per issue #97.

I've added a variable enableEmptyRow and I'm trying to avoid the check of empty rows in form.js when that variable is set to true. As for now it does not seems to work.