### PR TITLE
new devtools

### DIFF
--- a/app.js
+++ b/app.js
@@ -13,6 +13,12 @@ const omit = require('lodash').omit;
 const { app, BrowserWindow, ipcMain } = require('electron');
 const { autoUpdater } = require('electron-updater');
 
+// debugging tools
+require('electron-debug')({
+  // enabled: true, // force devtools in production
+  showDevTools: 'undocked' // show devtools on each created BrowserWindow
+});
+
 // Place a BrowserWindow in center of primary display
 const centerOnPrimaryDisplay = require('./helpers/center-on-primary-display');
 

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   },
   "dependencies": {
     "dotenv": "^4.0.0",
+    "electron-debug": "^1.5.0",
     "electron-is-dev": "^0.3.0",
     "electron-settings": "^3.1.2",
     "electron-updater": "^2.18.2",
@@ -74,7 +75,6 @@
     "duplicate-package-checker-webpack-plugin": "^1.2.6",
     "electron": "^1.7.10",
     "electron-builder": "^19.52.1",
-    "electron-debug": "^1.5.0",
     "electron-react-devtools": "^0.5.3",
     "enzyme": "^3.3.0",
     "enzyme-adapter-react-16": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -74,6 +74,8 @@
     "duplicate-package-checker-webpack-plugin": "^1.2.6",
     "electron": "^1.7.10",
     "electron-builder": "^19.52.1",
+    "electron-debug": "^1.5.0",
+    "electron-react-devtools": "^0.5.3",
     "enzyme": "^3.3.0",
     "enzyme-adapter-react-16": "^1.1.1",
     "eslint": "^4.15.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2620,6 +2620,13 @@ electron-builder@^19.52.1:
     update-notifier "^2.3.0"
     yargs "^10.0.3"
 
+electron-debug@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/electron-debug/-/electron-debug-1.5.0.tgz#d88c02146efb7fc5ae1b21eac56fbe4987eae50c"
+  dependencies:
+    electron-is-dev "^0.3.0"
+    electron-localshortcut "^3.0.0"
+
 electron-download-tf@4.3.4:
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/electron-download-tf/-/electron-download-tf-4.3.4.tgz#b03740b2885aa2ad3f8784fae74df427f66d5165"
@@ -2648,9 +2655,22 @@ electron-download@^3.0.1:
     semver "^5.3.0"
     sumchecker "^1.2.0"
 
+electron-is-accelerator@^0.1.0:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/electron-is-accelerator/-/electron-is-accelerator-0.1.2.tgz#509e510c26a56b55e17f863a4b04e111846ab27b"
+
 electron-is-dev@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/electron-is-dev/-/electron-is-dev-0.3.0.tgz#14e6fda5c68e9e4ecbeff9ccf037cbd7c05c5afe"
+
+electron-localshortcut@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/electron-localshortcut/-/electron-localshortcut-3.1.0.tgz#10c1ffd537b8d39170aaf6e1551341f7780dd2ce"
+  dependencies:
+    debug "^2.6.8"
+    electron-is-accelerator "^0.1.0"
+    keyboardevent-from-electron-accelerator "^1.1.0"
+    keyboardevents-areequal "^0.2.1"
 
 electron-osx-sign@0.4.7:
   version "0.4.7"
@@ -2673,6 +2693,10 @@ electron-publish@19.52.0:
     chalk "^2.3.0"
     fs-extra-p "^4.5.0"
     mime "^2.1.0"
+
+electron-react-devtools@^0.5.3:
+  version "0.5.3"
+  resolved "https://registry.yarnpkg.com/electron-react-devtools/-/electron-react-devtools-0.5.3.tgz#c74edb1245dc1cfe1380b93016cd4eb588ed00b7"
 
 electron-settings@^3.1.2:
   version "3.1.4"
@@ -5039,6 +5063,14 @@ jsx-ast-utils@^2.0.0:
   resolved "https://registry.yarnpkg.com/jsx-ast-utils/-/jsx-ast-utils-2.0.1.tgz#e801b1b39985e20fffc87b40e3748080e2dcac7f"
   dependencies:
     array-includes "^3.0.3"
+
+keyboardevent-from-electron-accelerator@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/keyboardevent-from-electron-accelerator/-/keyboardevent-from-electron-accelerator-1.1.0.tgz#324614f6e33490c37ffc5be5876b3e85fe223c84"
+
+keyboardevents-areequal@^0.2.1:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/keyboardevents-areequal/-/keyboardevents-areequal-0.2.2.tgz#88191ec738ce9f7591c25e9056de928b40277194"
 
 killable@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
added electron-debug & electron-react-devtools packages. electron-debug has a config option to force the debug tools in production.