### PR TITLE
Output taxID to templates if necessary

### DIFF
--- a/preview/templates/business/components/Header.jsx
+++ b/preview/templates/business/components/Header.jsx
@@ -63,7 +63,7 @@ const Heading = styled.h1`
 
 // Component
 function Header({ t, invoice, profile, configs }) {
-  const { recipient } = invoice;
+  const { tax, recipient } = invoice;
   const currentLanguage = configs.language;
   return (
     <InvoiceHeader>
@@ -74,7 +74,9 @@ function Header({ t, invoice, profile, configs }) {
           <p>{profile.address}</p>
           <p>{profile.email}</p>
           <p>{profile.phone}</p>
+          { tax && <p>Tax ID: { tax.tin }</p> }
         </Company>
+
         {configs.showRecipient && (
           <Recipient>
             <h4>{t('preview:common:billedTo', { lng: currentLanguage })}</h4>

--- a/preview/templates/minimal/components/Footer.jsx
+++ b/preview/templates/minimal/components/Footer.jsx
@@ -5,6 +5,7 @@ import PropTypes from 'prop-types';
 import styled from 'styled-components';
 const Wrapper = styled.div`
   display: flex;
+  align-items: flex-start;
   justify-content: space-between;
 `;
 
@@ -26,7 +27,7 @@ const Column = styled.div`
 // Component
 function Footer({ t, invoice, profile, configs }) {
   const currentLanguage = configs.language;
-  const { recipient } = invoice;
+  const { tax, recipient } = invoice;
   return (
     <Wrapper>
       <Column left>
@@ -35,6 +36,7 @@ function Footer({ t, invoice, profile, configs }) {
         <p>{profile.address}</p>
         <p>{profile.email}</p>
         <p>{profile.phone}</p>
+        { tax && <p>Tax ID: { tax.tin }</p> }
       </Column>
       {configs.showRecipient && (
         <Column right>

--- a/preview/templates/minimal/components/Header.jsx
+++ b/preview/templates/minimal/components/Header.jsx
@@ -32,12 +32,13 @@ const Heading = styled.h1`
 
 // Component
 function Header({ t, invoice, profile, configs }) {
-  const currentLanguage = configs.language;
+  const { language } = configs;
+  const { dueDate } = invoice;
   return (
     <Wrapper>
       <div>
         <Heading accentColor={configs.accentColor}>
-          {t('preview:common:invoice', {lng: currentLanguage})}
+          {t('preview:common:invoice', {lng: language})}
         </Heading>
         <h4 className="label">
           # {' '}
@@ -49,30 +50,30 @@ function Header({ t, invoice, profile, configs }) {
           }
         </h4>
         <p>
-          {t('preview:common:created', {lng: currentLanguage})}:
+          {t('preview:common:created', {lng: language})}:
           {' '}
-          {moment(invoice.created_at).lang(currentLanguage).format(configs.dateFormat)}
+          {moment(invoice.created_at).lang(language).format(configs.dateFormat)}
         </p>
-        {invoice.dueDate && [
+        {dueDate && [
           <p key="dueDate">
-            {t('preview:common:due', { lng: currentLanguage })}:{' '}
-            {invoice.dueDate.useCustom
-              ? moment(invoice.dueDate.selectedDate)
-                  .lang(currentLanguage)
+            {t('preview:common:due', { lng: language })}:{' '}
+            {dueDate.useCustom
+              ? moment(dueDate.selectedDate)
+                  .lang(language)
                   .format(configs.dateFormat)
               : moment(
-                  calTermDate(invoice.created_at, invoice.dueDate.paymentTerm)
+                  calTermDate(invoice.created_at, dueDate.paymentTerm)
                 )
-                  .lang(currentLanguage)
+                  .lang(language)
                   .format(configs.dateFormat)}
           </p>,
           <p key="dueDateNote">
-            {!invoice.dueDate.useCustom &&
+            {!dueDate.useCustom &&
               `
             (
               ${t(
                 `form:fields:dueDate:paymentTerms:${
-                  invoice.dueDate.paymentTerm
+                  dueDate.paymentTerm
                 }:description`
               )}
             )


### PR DESCRIPTION
### Description
Right now the Tax ID information is not displayed on any templates. This PR fixes that issue.

### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Issue #254

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have included a migration scheme (If type of change is breaking change)
