### PR TITLE
Added support for Windows 32 bit

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -14,8 +14,14 @@ mac:
     - dmg
 win:
   target:
-    - nsis
-    - portable
+    - target: nsis
+      arch:
+        - x64
+        - ia32
+    - target: portable
+      arch:
+        - x64
+        - ia32
 linux:
   category: Office
   target:


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
Updated `electron-builder` config to export Windows installer that supports 32 bit arch

### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Issue #185 

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Some users still running Windows with 32-bit arch and previous releases of Manta did not support this architecture. 

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

### Screenshots (if appropriate):

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have included a migration scheme (If type of change is breaking change)
