### PR TITLE
Update Dkr to DKK in danish

### DIFF
--- a/libs/currencies.json
+++ b/libs/currencies.json
@@ -270,7 +270,7 @@
     "name_plural": "Djiboutian francs"
   },
   "DKK": {
-    "symbol": "Dkr",
+    "symbol": "DKK",
     "name": "Danish Krone",
     "symbol_native": "kr",
     "decimal_digits": 2,


### PR DESCRIPTION
Most people in Denmark use DKK instead of Dkr now.
