### PR TITLE
Add missing date formats to Previewer

### DIFF
--- a/preview/components/sidebar/DateFormat.jsx
+++ b/preview/components/sidebar/DateFormat.jsx
@@ -39,6 +39,18 @@ function DateFormat({ t, dateFormat, handleInputChange, language, UILang }) {
         <option value="DD/MM/YY">
           {moment(Date.now()).lang(language).format('DD/MM/YY')} (DD/MM/YY)
         </option>
+        <option value="dddd, Do MMMM YYYY">
+          {moment(Date.now()).format('dddd, Do MMMM YYYY')} (dddd, Do MMMM YYYY)
+        </option>
+        <option value="Do MMMM YYYY">
+          {moment(Date.now()).format('Do MMMM YYYY')} (Do MMMM YYYY)
+        </option>
+        <option value="DD.MM.YYYY">
+          {moment(Date.now()).format('DD.MM.YYYY')} (DD.MM.YYYY)
+        </option>
+        <option value="DD.MM.YY">
+          {moment(Date.now()).format('DD.MM.YY')} (DD.MM.YY)
+        </option>
       </select>
     </Section>
   );


### PR DESCRIPTION
Adds the four (4) missing date formats to the Previewer which are available under Settings -> Invoice -> Other.