### PR TITLE
Update Belarusian Ruble ISO

### DIFF
--- a/app/components/form/__tests__/__snapshots__/Currency.spec.jsx.snap
+++ b/app/components/form/__tests__/__snapshots__/Currency.spec.jsx.snap
@@ -74,7 +74,7 @@ exports[`Renders correctly to the DOM matches snapshot 1`] = `
             Bangladeshi Taka
           </option>
           <option
-            value="BYR"
+            value="BYN"
           >
             Belarusian Ruble
           </option>

--- a/libs/currencies.json
+++ b/libs/currencies.json
@@ -170,13 +170,13 @@
     "code": "BWP",
     "name_plural": "Botswanan pulas"
   },
-  "BYR": {
-    "symbol": "BYR",
+  "BYN": {
+    "symbol": "BYN",
     "name": "Belarusian Ruble",
-    "symbol_native": "BYR",
-    "decimal_digits": 0,
+    "symbol_native": "Br",
+    "decimal_digits": 2,
     "rounding": 0,
-    "code": "BYR",
+    "code": "BYN",
     "name_plural": "Belarusian rubles"
   },
   "BZD": {


### PR DESCRIPTION
This PR updates Belarusian Ruble code with new ISO, add symbol and update digits.

### Description
BYR is no longer used after 2017. The new code is BYN. Since 2016 10000 BYR = 1 BYN

Added national symbol: Br [National bank link](http://www.nbrb.by/Press/Print/?nId=247)
<!--- Describe your changes in detail -->

### Related Issue
No

### Motivation and Context
Update according to ISO 4217

<!--- Why is this change required? What problem does it solve? -->

### How Has This Been Tested?
Not required

### Screenshots (if appropriate):
No

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x ] All new and existing tests passed.
- [ ] I have included a migration scheme (If type of change is breaking change)
