### PR TITLE
Fix typo in form.json

### DIFF
--- a/i18n/en/form.json
+++ b/i18n/en/form.json
@@ -10,7 +10,7 @@
   },
   "settings": {
     "name": "Form Settings",
-    "hint": "Toogle any field to make it required in the form."
+    "hint": "Toggle any field to make it required in the form."
   },
   "fields": {
     "items": {


### PR DESCRIPTION
Fixed a typo in `i18n/en/form.json` from "Toogle" to "Toggle".

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have included a migration scheme (If type of change is breaking change)
