### PR TITLE
fixes: #334 Multi-line input for notes

### DIFF
--- a/preview/templates/business/components/Footer.jsx
+++ b/preview/templates/business/components/Footer.jsx
@@ -9,6 +9,9 @@ const InvoiceFooter = styled.div`
     padding-bottom: 0.83333em;
     border-bottom: 4px solid #efefd1;
   }
+  p {
+    white-space: pre-wrap;
+  }
   ${props =>
     props.customAccentColor &&
     `


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
Changed styling in the Business template to display line breaks present in the note text.

### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#334 
### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
As per the original issue, this change allows users to more easily separate pieces of text in the note section from each other, increasing readability for the recipient of the invoice.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested visually and using chrome devtools. Made sure that the change does not affect rendering of other areas of the application. This is just a styling change, so I have not added any tests.

### Screenshots (if appropriate):
<img width="547" alt="Text entered into the form with line breaks now displays correctly." src="https://user-images.githubusercontent.com/13480136/67622175-5e861c00-f820-11e9-9c92-b95397dd7734.png">

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have included a migration scheme (If type of change is breaking change)
